### PR TITLE
Push release commits to correct branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,8 @@ jobs:
           yarn install --frozen-lockfile
           yarn version --new-version ${{ inputs.releaseversion }}
 
-      - name: Tag and push release version, updating 'main' with new version
-        run: |
-          git tag ${{ inputs.releaseversion }}
-          git push origin main
-          git push origin ${{ inputs.releaseversion }}
+      - name: Tag release
+        run: git tag ${{ inputs.releaseversion }}
 
       - name: Build pass-auth
         run: |
@@ -56,8 +53,14 @@ jobs:
       - name: Bump project version to next dev version
         run: yarn version --new-version ${{ inputs.nextversion }}
 
-      - name: Push version bump to GH
-        run: git push origin main
+      # Commits made to branch specified in workflow_dispatch, push that branch if possible
+      - name: Push release commits to GH
+        if: github.ref_type == 'branch' && github.ref_protected == false
+        run: git push origin ${{ github.ref_name }}
+
+      # Push the release tag we made above
+      - name: Push release tag to GH
+        run: git push origin ${{ inputs.releaseversion }}
 
       - name: Retag and push next dev image
         run: |


### PR DESCRIPTION
Echoes changes made to `pass-ui` release automation

* Move all git pushes to end of workflow
* Push to the branch specified in the manual workflow trigger instead of to `main` always