### PR TITLE
Generalize saml config

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -16,7 +16,7 @@ interface AppConfig {
 interface PassportConfig {
   strategy: string;
   multiSaml: {
-    jhu: {
+    saml: {
       entryPoint: string;
       cert: string;
     };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -36,7 +36,7 @@ export default function (): PassAuthAppConfig {
     passport: {
       strategy: process.env.PASSPORT_STRATEGY,
       multiSaml: {
-        jhu: {
+        saml: {
           entryPoint: process.env.SAML_ENTRY_POINT,
           cert: idpCert,
         },


### PR DESCRIPTION
- we were using JHU as a key in certain places and in efforts to make this applicable to multiple institutions we should move away from this approach