### PR TITLE
chore: update root route handling in absence of pass-ui-public

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   pass-auth:
-    image: ghcr.io/eclipse-pass/pass-auth:0.4.0-SNAPSHOT
+    image: ghcr.io/eclipse-pass/pass-auth:0.7.0-SNAPSHOT
     build:
       context: .
     restart: always

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -10,6 +10,14 @@ export default function (
   strategy: MultiSamlStrategy,
   urlencodedParser: RequestHandler
 ): void {
+  app.get('/', (req: Request, res: Response) => {
+    if (req.isAuthenticated()) {
+      res.redirect(config.app.passUiPath);
+    } else {
+      res.redirect(config.app.logoutPath);
+    }
+  });
+
   app.get(
     config.app.loginPath,
     passport.authenticate('saml', {


### PR DESCRIPTION
related: https://github.com/eclipse-pass/pass-docker/pull/342